### PR TITLE
Add Agent Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 |---|---|---|---|---|
 | 🔥 | sandboxed-agents | https://github.com/kailiu42/sandboxed-agents | bwrap, sandbox, profiles | Unified bwrap sandbox wrapper for multiple coding agents — oh-my-pi, Claude Code, Codex — with per-agent profiles and layered config |
 | 👀 | forkd | https://github.com/deeplethe/forkd | microvm, fan-out, snapshots | MicroVM sandbox runtime for AI agent fan-out — fork 100 microVMs in ~100ms, BRANCH a live VM in ~150ms, KVM-isolated snapshot CoW |
+| 👀 | Agent Teams | https://github.com/777genius/agent-teams-ai | desktop, orchestration, kanban, review | You're the boss, agents are your team. They handle tasks on their own, message each other, and review each other's work. You just watch the kanban board and give high-level commands. Codex/Claude/OpenCode(200+ models, 75+ LLM providers, free models no auth). Build your AI company with multiple teams. |
 
 ## Token Savers
 


### PR DESCRIPTION
Adds Agent Teams to the CLI Agent Helpers section.

Agent Teams is a desktop orchestration workspace for existing coding agents across Claude, Codex, and OpenCode. Users give high-level commands while agents handle Kanban tasks, messaging, code review, logs, and approvals.

Rules followed:
- README.md only
- Existing catalog table format
- Status set to recently discovered
- No generated GitHub metrics added

Validation:
- npm run validate:catalog
- git diff --check