### PR TITLE
feat: add Relay to Subscription Management — universal LLM proxy with auto-rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 | Status | Tool | Repo | Tags | Description |
 |---|---|---|---|---|
 | 🧪 | OpenUsage | https://github.com/robinebers/openusage | subscriptions, usage, dashboard | Track all your AI coding subscriptions in one place |
+| 👀 | Relay | https://github.com/ImBIOS/relay | llm-proxy, provider-switch, usage, quota-rotation | Universal AI API proxy — hot-switch between GitHub Copilot, OpenAI, Anthropic, DeepSeek, Groq, Ollama, and 10+ providers from Claude Code, Codex CLI, Aider, or any coding agent without restarting. Auto-rotates accounts when quota exhausted, real-time usage tracking |
 
 ---
 


### PR DESCRIPTION
## What is Relay?

[Relay](https://github.com/ImBIOS/relay) is a universal AI API proxy that fills a gap in the current Subscription Management section: it doesn't just track subscriptions, it actively manages them by routing through a stable local endpoint and auto-rotating to the next account when quota is exhausted.

## Why it belongs here

- **Problem it solves**: AI coding agents (Claude Code, Codex CLI, Aider) cache the provider URL at session start. When quota runs out mid-session, you're stuck. Relay sits in front, rotates accounts automatically, and the agent never sees the switch.
- **Usage tracking**: Real-time quota monitoring with percentage used and reset timers for GitHub Copilot, Z.AI, and MiniMax.
- **14+ providers**: GitHub Copilot, OpenAI, Anthropic, DeepSeek, Groq, Ollama, Z.AI, MiniMax, OpenRouter, xAI, Cerebras, Google AI Studio, plus generic OpenAI/Anthropic-compatible endpoints.
- **Protocol translation**: Anthropic ↔ OpenAI, so any agent works with any provider.
- **Agent-agnostic**: Works with Claude Code, Codex CLI, Aider, Cline, Continue, OpenCode, and any tool that speaks Anthropic or OpenAI protocol.

TypeScript + Bun, MIT licensed. Install: `pnpm install -g github:ImBIOS/relay`