### PR TITLE
Add ax to subscription management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 | Status | Tool | Tags | Description |
 |---|---|---|---|
 | 🧪 | [OpenUsage](https://github.com/robinebers/openusage) | subscriptions, usage, dashboard | Track all your AI coding subscriptions in one place |
+| 👀 | [ax](https://github.com/Necmttn/ax) | telemetry, dashboard, mcp, usage | Local-first observability and memory layer for AI coding-agent sessions |
 | 👀 | [Relay](https://github.com/ImBIOS/relay) | llm-proxy, provider-switch, usage, quota-rotation | Universal AI API proxy — hot-switch between GitHub Copilot, OpenAI, Anthropic, DeepSeek, Groq, Ollama, and 10+ providers from Claude Code, Codex CLI, Aider, or any coding agent without restarting. Auto-rotates accounts when quota exhausted, real-time usage tracking |
 
 ---


### PR DESCRIPTION
Adds ax to Subscription Management.

ax fits this catalog as a local-first observability and memory layer for AI coding-agent sessions, with telemetry, dashboard, MCP, and usage analytics.

Validation:
- `npm run validate:catalog`
- `npm test`

---

_Generated with [ax](https://github.com/Necmttn/ax)._