### PR TITLE
Add Oh My Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | 👀 | [forkd](https://github.com/deeplethe/forkd) | microvm, fan-out, snapshots | MicroVM sandbox runtime for AI agent fan-out — fork 100 microVMs in ~100ms, BRANCH a live VM in ~150ms, KVM-isolated snapshot CoW |
 | 👀 | [Agent Teams](https://github.com/777genius/agent-teams-ai) | desktop, orchestration, kanban, review | You're the boss, agents are your team. They handle tasks on their own, message each other, and review each other's work. You just watch the kanban board and give high-level commands. Codex/Claude/OpenCode(200+ models, 75+ LLM providers, free models no auth). Build your AI company with multiple teams. |
 | 👀 | [Hephaestus](https://github.com/agentlas-ai/Hephaestus) | agent-os, routing, skills, memory | Open Agent OS for Claude Code, Codex, and Cursor with meta-agent building, A2A Hub routing, local ontology, and governed memory/security gates |
+| 👀 | [Oh My Hermes](https://github.com/rlaope/oh-my-hermes) | hermes, skills, workflows | Workflow skill pack for Hermes Agent that adds research, planning, coding handoff, review, QA, documentation, and long-running loop workflows |
 | 👀 | [Agent Island](https://github.com/tristan666666/agent-island) | macos, notch, monitoring, auto-resume | Native macOS notch companion for Claude Code and Codex sessions with live status and auto-resume for selected long-running tasks |
 
 


### PR DESCRIPTION
Adds Oh My Hermes, an open-source workflow skill pack for Hermes Agent.

OMH adds Hermes-native workflows for research, planning, coding handoffs, review, QA, documentation, and long-running loops.

Project: https://github.com/rlaope/oh-my-hermes
Docs: https://rlaope.github.io/oh-my-hermes/

Validation: npm run validate:catalog