### PR TITLE
Add OpenAgentRelay to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | 👀 | [Oh My Hermes](https://github.com/rlaope/oh-my-hermes) | hermes, skills, workflows | Workflow skill pack for Hermes Agent that adds research, planning, coding handoff, review, QA, documentation, and long-running loop workflows |
 | 👀 | [Agent Island](https://github.com/tristan666666/agent-island) | macos, notch, monitoring, auto-resume | Native macOS notch companion for Claude Code and Codex sessions with live status and auto-resume for selected long-running tasks |
 | 👀 | [RDLeader](https://github.com/happysnaker/RDLeader) | agent-ops, control-plane, approvals, qa-evidence | Local-first control plane for supervising AI R&D workers — task ownership, runtime dispatch, result collection, approval gates, public-safe demo reset, and QA evidence |
+| 👀 | [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) | trusted-lan, delegation, json, local-first | Turn any local agent or automation into a team-callable capability. |
 
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary

Adds OpenAgentRelay to **CLI Agent Helpers** with status `👀`.

The description uses the repository's GitHub About text verbatim. The tags identify its trusted-LAN delegation, JSON output, and local-first boundary.

## Validation

- `npm run validate:catalog`
- `make deploy` (catalog validation, 12 tests, and site build all passed)
