### PR TITLE
Add Agent-Ready Repo Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 | 👀 | [RDLeader](https://github.com/happysnaker/RDLeader) | agent-ops, control-plane, approvals, qa-evidence | Local-first control plane for supervising AI R&D workers — task ownership, runtime dispatch, result collection, approval gates, public-safe demo reset, and QA evidence |
 | 👀 | [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) | trusted-lan, delegation, json, local-first | Turn any local agent or automation into a team-callable capability. |
 | 👀 | [breaking-coding-chaos](https://github.com/bo-cao/breaking-coding-chaos) | control-plane, skills, human-in-the-loop | Human-in-the-loop dual-loop skill suite for coding agents: throughline progress on disk, plan-spar alignment, then minimal clean-cut implement |
+| 👀 | [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) | repository-audit, agent-readiness, github-actions | Free GitHub Action that scores public repositories for Codex, Claude Code, Copilot, and Cursor readiness—without cloning or executing code. |
 
 
 ## Agent Instructions


### PR DESCRIPTION
Adds [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) to **CLI Agent Helpers** as a recently discovered tool.

The entry uses the repository's GitHub About description verbatim and links only to the free open-source repository. It fits the helper category because it audits public repository evidence for Codex, Claude Code, Copilot, and Cursor workflows without cloning or executing the target code.

Validation: `npm run validate:catalog` — 24 tools across 5 categories.