### PR TITLE
Add Claudexor to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | 👀 | [breaking-coding-chaos](https://github.com/bo-cao/breaking-coding-chaos) | control-plane, skills, human-in-the-loop | Human-in-the-loop dual-loop skill suite for coding agents: throughline progress on disk, plan-spar alignment, then minimal clean-cut implement |
 | 👀 | [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) | repository-audit, agent-readiness, github-actions | Free GitHub Action that scores public repositories for Codex, Claude Code, Copilot, and Cursor readiness—without cloning or executing code. |
 | 👀 | [Better Agent](https://github.com/ofekron/better-agent) | orchestration, dashboard, approvals, multi-provider | Local web workspace for coding agents — Claude, Codex, Gemini, and more in one inspectable, LAN-ready hub. |
+| 👀 | [Claudexor](https://github.com/razzant/claudexor) | control-plane, multi-harness, best-of-n, review | Local-first control plane for AI coding harnesses (Codex, Claude Code, Cursor, OpenCode): best-of-N runs, multi-model review, evidence-driven delivery |
 
 
 ## Agent Instructions


### PR DESCRIPTION
## What changed

Adds Claudexor to the CLI Agent Helpers catalog with `👀` status.

## Why it fits

Claudexor is a local-first control plane for Codex, Claude Code, Cursor, and OpenCode. It coordinates best-of-N runs, multi-model review, and evidence-driven delivery rather than acting as another standalone coding agent.

The row uses the repository's GitHub About description and follows the four-column catalog format.

## Validation

- `npm run validate:catalog`
- `npm test`
- `git diff --check`

Project: https://github.com/razzant/claudexor
