### PR TITLE
Add fractal to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | 👀 | [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) | repository-audit, agent-readiness, github-actions | Free GitHub Action that scores public repositories for Codex, Claude Code, Copilot, and Cursor readiness—without cloning or executing code. |
 | 👀 | [Better Agent](https://github.com/ofekron/better-agent) | orchestration, dashboard, approvals, multi-provider | Local web workspace for coding agents — Claude, Codex, Gemini, and more in one inspectable, LAN-ready hub. |
 | 👀 | [Claudexor](https://github.com/razzant/claudexor) | control-plane, multi-harness, best-of-n, review | Local-first control plane for AI coding harnesses (Codex, Claude Code, Cursor, OpenCode): best-of-N runs, multi-model review, evidence-driven delivery |
+| 👀 | [fractal](https://github.com/plasma-ai/fractal) | orchestration, recursive-delegation, git-worktrees, tui | Hierarchical agent loops with recursive self-organization. |
 
 
 ## Agent Instructions


### PR DESCRIPTION
## Summary

Adds [fractal](https://github.com/plasma-ai/fractal) to **CLI Agent Helpers**.

fractal is a Python runtime for hierarchical coding-agent loops. Each node runs in its own Git worktree, can delegate separable subtasks to child nodes, persists run state in SQLite, and can be monitored and steered through a terminal UI.

Disclosure: I am affiliated with Plasma AI, which maintains fractal.

## Validation

- `npm run validate:catalog`
- `make deploy`
