### PR TITLE
Add wiki to Knowledge & Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@
 |---|---|---|---|
 | 🔥 | [coding-agent-instructions](https://github.com/kailiu42/coding-agent-instructions) | instructions, rules, progressive-disclosure | Rules for coding agents. Modular design, progressive disclosure without eating your context window or distract your agents |
 
+## Knowledge & Context
+
+| Status | Tool | Tags | Description |
+|---|---|---|---|
+| 👀 | [wiki](https://github.com/plasma-ai/wiki) | knowledge-base, markdown, cli, agent-skills | Indexed knowledge bases with command-line tools for agents. |
+
 ## Token Savers
 
 | Status | Tool | Tags | Description |


### PR DESCRIPTION
## Summary

Add [wiki](https://github.com/plasma-ai/wiki) under a new **Knowledge & Context** category.

No existing category clearly covers a project knowledge-base tool. The row uses the repository's GitHub About description and the `👀` status for a recently discovered tool, following the catalog conventions.

Validation:

- `npm run validate:catalog`

Disclosure: I'm affiliated with the project.