### PR TITLE
Add aGiTrack to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | 👀 | [Better Agent](https://github.com/ofekron/better-agent) | orchestration, dashboard, approvals, multi-provider | Local web workspace for coding agents — Claude, Codex, Gemini, and more in one inspectable, LAN-ready hub. |
 | 👀 | [Claudexor](https://github.com/razzant/claudexor) | control-plane, multi-harness, best-of-n, review | Local-first control plane for AI coding harnesses (Codex, Claude Code, Cursor, OpenCode): best-of-N runs, multi-model review, evidence-driven delivery |
 | 👀 | [fractal](https://github.com/plasma-ai/fractal) | orchestration, recursive-delegation, git-worktrees, tui | Hierarchical agent loops with recursive self-organization. |
+| 👀 | [aGiTrack](https://github.com/core-aix/agitrack) | git, commits, token-accounting, dashboard | Terminal wrapper for Claude Code, Codex, and OpenCode that commits each agent turn to git, recording the prompt, model, and that turn's input/output/cache token counts in the commit message, with a local dashboard over the resulting history |
 
 
 ## Agent Instructions


### PR DESCRIPTION
Adds aGiTrack as a new row at the end of the **CLI Agent Helpers** table, with the 👀 status since that is yours to set, not mine.

Disclosure: I'm the author.

aGiTrack (Apache-2.0, `pip install agitrack`) runs Claude Code, Codex, or OpenCode and commits each agent turn to git automatically. The commit message records the backend, model, and that turn's input, output, cache-read, and cache-write token counts, so `git log` alone shows what an agent changed and what it cost. Agents run in an isolated worktree, and a local dashboard summarises commits, sessions, and token spend.