### PR TITLE
Add Sillage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | 👀 | [Claudexor](https://github.com/razzant/claudexor) | control-plane, multi-harness, best-of-n, review | Local-first control plane for AI coding harnesses (Codex, Claude Code, Cursor, OpenCode): best-of-N runs, multi-model review, evidence-driven delivery |
 | 👀 | [fractal](https://github.com/plasma-ai/fractal) | orchestration, recursive-delegation, git-worktrees, tui | Hierarchical agent loops with recursive self-organization. |
 | 👀 | [aGiTrack](https://github.com/core-aix/agitrack) | git, commits, token-accounting, dashboard | Terminal wrapper for Claude Code, Codex, and OpenCode that commits each agent turn to git, recording the prompt, model, and that turn's input/output/cache token counts in the commit message, with a local dashboard over the resulting history |
+| 👀 | [Sillage](https://github.com/MarlBurroW/sillage) | web-ui, self-hosted, pwa | Mobile-first self-hosted web UI that drives the native Claude Code and Codex CLIs on your own machine; sessions that outlive the client, an IDE panel, its own MCP server, single Docker container |
 
 
 ## Agent Instructions


### PR DESCRIPTION
Adds **Sillage** to the `CLI Agent Helpers` section (status 👀), alongside other local web workspaces for coding CLIs (Better Agent, Claudexor).

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine. Sessions that outlive the client, full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

Repo: https://github.com/MarlBurroW/sillage

Four-column table format respected (Status, Tool, Tags, Description); Tool is a GitHub link.

Disclosure: I am the author of Sillage.