### PR TITLE
Add AI Badger to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 | 👀 | [Sillage](https://github.com/MarlBurroW/sillage) | web-ui, self-hosted, pwa | Mobile-first self-hosted web UI that drives the native Claude Code and Codex CLIs on your own machine; sessions that outlive the client, an IDE panel, its own MCP server, single Docker container |
 | 👀 | [Chump](https://github.com/repairman29/chump) | multi-agent, coordination, local-first, offline | Self-hosted AI coding agent with persistent memory and bounded autonomy. Local-first, your keys, your data. Written in Rust. |
 | 👀 | [pisesh](https://github.com/Blue-B/pisesh) | tui, sessions, favorites, search | Keyboard-driven TUI to bookmark, search, rename, and resume pi coding-agent sessions — per-project view, cwd overrides, optional AI title generation, zero dependencies |
+| 👀 | [AI Badger](https://github.com/PVRLabs/aibadger) | local-first, context, code-review, handoff | AI Badger - Local-first tool that extracts focused repo context for any AI chat (Claude, ChatGPT, Grok, etc.) without wasting tokens on irrelevant files. |
 
 ## Agent Instructions
 


### PR DESCRIPTION
## Summary

- Add AI Badger to the CLI Agent Helpers category.
- Highlight its local-first repository context extraction and AI chat compatibility.
- Include review and handoff workflow tags.

## Testing

- npm run validate:catalog
- make deploy
- All 12 tests passed.