### PR TITLE
Add agent-scripts to Token Savers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 |---|---|---|---|
 | 🧪 | [rtk](https://github.com/rtk-ai/rtk) | token-saving, proxy, rust | CLI proxy that reduces LLM token consumption by 60-90% on common dev commands — single Rust binary, zero dependencies |
 | 🧪 | [ponytail](https://github.com/DietrichGebert/ponytail) | token-saving, agent-skills, minimalism | Makes your AI agent think like the laziest senior dev in the room. The best code is the code you never wrote. |
+| 👀 | [agent-scripts](https://github.com/ejboy/agent-scripts) | token-saving, build-output, local-first | Token-efficient, local-first CLI tools for coding agents - compact Maven, npm/Node, and Go test output plus reusable development helpers. |
 
 ## Subscription Management
 


### PR DESCRIPTION
## Summary

- Add agent-scripts to the Token Savers category.
- Highlight its local-first, token-efficient CLI helpers.
- Document compact Maven, npm/Node, and Go test output workflows.

## Testing

- npm run validate:catalog
- git diff --check