### PR TITLE
Add kgai to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 | 👀 | [Sillage](https://github.com/MarlBurroW/sillage) | web-ui, self-hosted, pwa | Mobile-first self-hosted web UI that drives the native Claude Code and Codex CLIs on your own machine; sessions that outlive the client, an IDE panel, its own MCP server, single Docker container |
 | 👀 | [Chump](https://github.com/repairman29/chump) | multi-agent, coordination, local-first, offline | Self-hosted AI coding agent with persistent memory and bounded autonomy. Local-first, your keys, your data. Written in Rust. |
 | 👀 | [pisesh](https://github.com/Blue-B/pisesh) | tui, sessions, favorites, search | Keyboard-driven TUI to bookmark, search, rename, and resume pi coding-agent sessions — per-project view, cwd overrides, optional AI title generation, zero dependencies |
+| 👀 | [kgai](https://github.com/kgaidev/kgai) | memory, decisions, local-first, s3-sync | Shared memory for AI dev teams — an immutable knowledge graph of the decisions behind your code, auto-captured by your agent and synced without merge conflicts. |
 
 ## Agent Instructions
 


### PR DESCRIPTION
Adds kgai to CLI Agent Helpers, last row of the table. Disclosure: we build it.

Following AGENTS.md: four columns, status 👀 (you have not tried it), tags as distinguishing traits (memory, decisions, local-first, s3-sync), and the description is the repo's GitHub About text verbatim. Tool link is the GitHub repo.

What it is, in one breath: a Claude Code plugin plus a standalone Go CLI that records the decisions behind a codebase into an append-only local log, recalls only the decisions still in force before the agent edits, and syncs the log across a team over an S3 bucket the team owns, no server. It sits next to Tree Ring Memory in this table as the decision-level, team-shared counterpart.

One row, nothing else touched. `npm run validate:catalog` should pass on the row as written. Happy to adjust tags or move it if you think it fits better elsewhere.
