### PR TITLE
docs: add SandBase CLI to CLI agent helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 |---|---|---|---|
 | 🔥 | [sandboxed-agents](https://github.com/kailiu42/sandboxed-agents) | bwrap, sandbox, profiles | Unified bwrap sandbox wrapper for multiple coding agents — oh-my-pi, Claude Code, Codex — with per-agent profiles and layered config |
 | 👀 | [codex-profiles](https://github.com/Ducksss/codex-profiles) | codex, profiles, account-switching | Codex CLI/Desktop profile switcher that launches Codex with isolated CODEX_HOME directories for separate auth, config, sessions, plugins, and logs |
+| 👀 | [SandBase CLI](https://github.com/sandbaseai/cli) | mcp, model-routing, cli | Local MCP bridge CLI that lets coding clients discover and run 2,000+ AI models and APIs |
 | 👀 | [codex-fixes](https://github.com/zhuhaow/codex-fixes) | codex, fixes, issue-registry | Checks your local Codex install for known issues and runs the matching community-maintained fix scripts |
 | 👀 | [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) | loop-engineering, verification, agent-packets | Local-first CLI and templates for turning rough coding-agent context into verifiable loop specs, agent packets, verifier gates, stop rules, rollback rules, and JSON reports |
 | 👀 | [py_ralph_frame](https://github.com/rxdt/py_ralph_frame) | loop-engineering, verification, agent-loops | A lightweight spec-driven loop harness for Claude Code, Codex, and Gemini CLI. Fresh-context runs, specs, commits, and gates to get you and your agents productive immediately. |


### PR DESCRIPTION
## Description
Adds SandBase CLI to CLI Agent Helpers as a local MCP bridge for coding clients.

- Canonical repository: https://github.com/sandbaseai/cli
- Tags: mcp, model-routing, cli
- Factual description of discovering and running 2,000+ AI models and APIs

Disclosure: I contribute to SandBase CLI. The entry follows the four-column catalog format and links to the canonical project.