### PR TITLE
Add AGENTS.md Starter Kit to Agent Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 | Status | Tool | Tags | Description |
 |---|---|---|---|
 | 🔥 | [coding-agent-instructions](https://github.com/kailiu42/coding-agent-instructions) | instructions, rules, progressive-disclosure | Rules for coding agents. Modular design, progressive disclosure without eating your context window or distract your agents |
+| 👀 | [AGENTS.md Starter Kit](https://github.com/sunxiayi/agents-md-starter-kit) | agents-md, templates, cli, github-actions | One-command AGENTS.md starter templates for monorepos, Python, Next.js, Codex, Claude Code, Cursor, Copilot, Gemini CLI, and Windsurf. |
 
 ## Knowledge & Context
 


### PR DESCRIPTION
## Summary

- add AGENTS.md Starter Kit to the existing Agent Instructions category
- use the exact GitHub About description and a newly discovered status
- change one README line only

## Validation

- `npm run validate:catalog`
- `make deploy`

## Disclosure

I maintain the listed repository. This contribution is part of a 30-day public growth experiment for Repo Agent Kit; the catalog entry links only to the open-source GitHub repository and follows the repository add-tool contract.
