### PR TITLE
Add chamnan to Knowledge & Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 | Status | Tool | Tags | Description |
 |---|---|---|---|
 | 👀 | [wiki](https://github.com/plasma-ai/wiki) | knowledge-base, markdown, cli, agent-skills | Indexed knowledge bases with command-line tools for agents. |
+| 👀 | [chamnan](https://github.com/ArcticFox2029/chamnan) | context, architecture-index, impact-map, local-first, stdlib-only | Preserves a long-lived repository's engineering context — an architecture index, an impact map, session records, and the decisions behind them — as markdown committed beside the code, so an agent reads instead of rediscovering. |
 
 ## Token Savers
 


### PR DESCRIPTION
Adding **[chamnan](https://github.com/ArcticFox2029/chamnan)** to Knowledge & Context.

It keeps a long-lived repository's engineering context — an architecture index, an impact map, session records, and the decisions behind them — as markdown committed beside the code, so an agent reads it at startup instead of rediscovering the same structure every session.

Following the conventions in AGENTS.md:

- Status `👀` — your own definition, and mine to claim least: I wrote it, so it is you who would decide it is more
- Four columns, Tool is a markdown link to the GitHub repo
- Tags are lowercase and comma-separated, chosen for what distinguishes it rather than broad taxonomy
- Description is the repo's own About text
- No metrics written into the markdown

`npm run validate:catalog` and `make deploy` both pass locally (12/12 tests, 39 tools across 6 categories).

Relevant to how this list is framed: it is Python standard library only, makes no network calls at runtime, and runs no daemon or background process. Everything it produces is plain text committed beside the code, so it works offline and leaves nothing behind if removed.