### PR TITLE
Add YYLO to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 | 👀 | [pisesh](https://github.com/Blue-B/pisesh) | tui, sessions, favorites, search | Keyboard-driven TUI to bookmark, search, rename, and resume pi coding-agent sessions — per-project view, cwd overrides, optional AI title generation, zero dependencies |
 | 👀 | [AI Badger](https://github.com/PVRLabs/aibadger) | local-first, context, code-review, handoff | AI Badger - Local-first tool that extracts focused repo context for any AI chat (Claude, ChatGPT, Grok, etc.) without wasting tokens on irrelevant files. |
 | 👀 | [kgai](https://github.com/kgaidev/kgai) | memory, decisions, local-first, s3-sync | Shared memory for AI dev teams — an immutable knowledge graph of the decisions behind your code, auto-captured by your agent and synced without merge conflicts. |
+| 👀 | [YYLO](https://github.com/yylo-dev/yylo) | orchestration, kanban, git-worktrees, multi-agent | YYLO (why-lo): AI coding-agent orchestration CLI with equivalent yylo and yy launchers. |
 
 ## Agent Instructions
 


### PR DESCRIPTION
Adds YYLO to CLI Agent Helpers, last row of the table. Disclosure: we maintain it.

Following AGENTS.md: four columns, status 👀 (you have not tried it), tags as distinguishing traits (orchestration, kanban, git-worktrees, multi-agent), and the description is the repo's GitHub About text verbatim. Tool link is the GitHub repo.

What it is, in one breath: a terminal orchestrator that runs CLI coding agents (Claude Code, Codex, Gemini CLI) in parallel across isolated git worktrees, tracked on a Kanban board with review gates and typed merge/release flows — it sits next to Agent Teams and fractal in this table as the worktree-fan-out orchestrator counterpart. Install via `npm i -g @yylo/cli`, MIT-licensed.

One row, nothing else touched. `npm run validate:catalog` passes on the row as written (28 tools in CLI Agent Helpers). Happy to adjust tags or move it if you think it fits better elsewhere.

Source repository: https://github.com/yylo-dev/yylo