### PR TITLE
Add YYLO Benchmark to CLI Agent Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 | 👀 | [AI Badger](https://github.com/PVRLabs/aibadger) | local-first, context, code-review, handoff | AI Badger - Local-first tool that extracts focused repo context for any AI chat (Claude, ChatGPT, Grok, etc.) without wasting tokens on irrelevant files. |
 | 👀 | [kgai](https://github.com/kgaidev/kgai) | memory, decisions, local-first, s3-sync | Shared memory for AI dev teams — an immutable knowledge graph of the decisions behind your code, auto-captured by your agent and synced without merge conflicts. |
 | 👀 | [YYLO](https://github.com/yylo-dev/yylo) | orchestration, kanban, git-worktrees, multi-agent | YYLO (why-lo): AI coding-agent orchestration CLI with equivalent yylo and yy launchers. |
+| 👀 | [YYLO Benchmark](https://github.com/yylo-dev/yylo-benchmark) | evaluation, benchmarks, evidence, worktrees | YYLO Benchmark: longitudinal evaluation and immutable evidence for agent runs. |
 
 ## Agent Instructions
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 | 👀 | [pisesh](https://github.com/Blue-B/pisesh) | tui, sessions, favorites, search | Keyboard-driven TUI to bookmark, search, rename, and resume pi coding-agent sessions — per-project view, cwd overrides, optional AI title generation, zero dependencies |
 | 👀 | [AI Badger](https://github.com/PVRLabs/aibadger) | local-first, context, code-review, handoff | AI Badger - Local-first tool that extracts focused repo context for any AI chat (Claude, ChatGPT, Grok, etc.) without wasting tokens on irrelevant files. |
 | 👀 | [kgai](https://github.com/kgaidev/kgai) | memory, decisions, local-first, s3-sync | Shared memory for AI dev teams — an immutable knowledge graph of the decisions behind your code, auto-captured by your agent and synced without merge conflicts. |
+| 👀 | [YYLO](https://github.com/yylo-dev/yylo) | orchestration, kanban, git-worktrees, multi-agent | YYLO (why-lo): AI coding-agent orchestration CLI with equivalent yylo and yy launchers. |
 
 ## Agent Instructions
 


### PR DESCRIPTION
Adds **YYLO Benchmark** to the `CLI Agent Helpers` table — the eval/evidence sibling of the YYLO orchestrator (#44, also mine).

**Note on stacking:** this branch is stacked on #44's branch because both rows append at the same table position, so until #44 merges the diff shows two rows; once #44 merges this PR automatically reduces to the single row below (no conflict in either merge order).

**Row added** (appended at the bottom of the table, one row, nothing else touched):

`| 👀 | [YYLO Benchmark](https://github.com/yylo-dev/yylo-benchmark) | evaluation, benchmarks, evidence, worktrees | YYLO Benchmark: longitudinal evaluation and immutable evidence for agent runs. |`

Following AGENTS.md and the add-tool skill:
- Status `👀` — self-submitted / recently discovered.
- Description is the GitHub repo **About text verbatim**: "YYLO Benchmark: longitudinal evaluation and immutable evidence for agent runs."
- Tool name is the official name; link is the canonical GitHub repo URL.
- Tags are short lowercase distinguishing traits (no broad taxonomy) — happy to adjust them.
- No stars/metrics written into Markdown.

One-breath description: YYLO Benchmark runs longitudinal evaluations of CLI coding agents (Claude Code, Codex, Gemini CLI) with per-attempt isolated git worktrees and ordered deterministic + LLM evaluator profiles, producing immutable evidence for each agent run — it sits beside the evidence/QA-flavored helpers already in the table (Claudexor's evidence-driven delivery, RDLeader's qa-evidence).

`npm run validate:catalog` passes: **41 tools across 6 categories, 0 errors** (CLI Agent Helpers: 29).

Full disclosure: I maintain the YYLO project family (yylo-dev). One row, nothing else touched — happy to adjust tags or placement.